### PR TITLE
More/better TFMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+.vs/
 
 # Build results
 [Dd]ebug/

--- a/src/DeltaCompressionDotNet/DeltaCompressionDotNet.csproj
+++ b/src/DeltaCompressionDotNet/DeltaCompressionDotNet.csproj
@@ -3,6 +3,6 @@
   <PropertyGroup>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;net20</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/test/DeltaCompressionDotNet.Tests/DeltaCompressionDotNet.Tests.csproj
+++ b/test/DeltaCompressionDotNet.Tests/DeltaCompressionDotNet.Tests.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;net472</TargetFrameworks>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DeltaCompressionDotNet\DeltaCompressionDotNet.csproj" />


### PR DESCRIPTION
Per #17, the latest nuget.org package targets `net20` (.NET Framework 2.0). But the latest source in the repo dropped support for that and added `netstandard1.3` instead. 
Before we push the latest version of the package to nuget.org to address the .NET Core users out there, this PR brings back `net20` support.

It also adds `netstandard2.0`, which is preferable since it brings in fewer facade assemblies.
It also adds test execution on .NET Framework, whereas before it only tested on .NET 5.